### PR TITLE
feat: optionally display only CSV data or boundary data

### DIFF
--- a/src/DocumentReview.tsx
+++ b/src/DocumentReview.tsx
@@ -7,8 +7,8 @@ import { Global, css } from "@emotion/react";
 import { checkAnswerProps } from "./helpers";
 
 export type DocumentReviewProps = React.PropsWithChildren<{
-  geojson: object;
-  csv: QuestionAnswer[];
+  geojson?: object;
+  csv?: QuestionAnswer[];
 }>;
 
 export default function DocumentReview(
@@ -22,7 +22,7 @@ export default function DocumentReview(
         spacing={2}
         direction="row-reverse"
         sx={{
-          justifyContent: "center",
+          justifyContent: "flex-end",
           minWidth: "650px",
           maxWidth: "1400px",
           padding: "0 1em",
@@ -32,14 +32,18 @@ export default function DocumentReview(
         <Grid item xs={12}>
           <h1>Review Document</h1>
         </Grid>
-        <Grid item xs={12} md={6}>
-          <h2>Boundary</h2>
-          <MapView geojson={props.geojson} />
-        </Grid>
-        <Grid item xs={12} md={6} sx={{ paddingTop: 0 }}>
-          <h2>Data</h2>
-          <AnswerView csv={props.csv} />
-        </Grid>
+        {props?.geojson && (
+          <Grid item xs={12} md={6}>
+            <h2>Boundary</h2>
+            <MapView geojson={props.geojson} />
+          </Grid>
+        )}
+        {props?.csv && (
+          <Grid item xs={12} md={6} sx={{ paddingTop: 0 }}>
+            <h2>Data</h2>
+            <AnswerView csv={props.csv} />
+          </Grid>
+        )}
       </Grid>
     </React.Fragment>
   );

--- a/types/DocumentReview.d.ts
+++ b/types/DocumentReview.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 export type DocumentReviewProps = React.PropsWithChildren<{
-    geojson: object;
-    csv: QuestionAnswer[];
+    geojson?: object;
+    csv?: QuestionAnswer[];
 }>;
 export default function DocumentReview(props: DocumentReviewProps): React.ReactElement<DocumentReviewProps, any>;
 export type QuestionAnswer = {


### PR DESCRIPTION
For the initial Uniform use case, it made perfect sense to display both the CSV data & boundary data side by side. 

But, I'm thinking it might be nice to have flexibility to also only provide one or the other for a more focused document viewer - eg only show the map. This is already possible by just omitting a prop, but this PR cleans up the types to reflect this option and conditionally renders the grid items. Implemented here https://github.com/theopensystemslab/planx-new/pull/1353

Before:
![Screenshot from 2022-12-22 11-41-10](https://user-images.githubusercontent.com/5132349/209126558-a70246f8-6e8b-42a5-95d3-376ee42da696.png)

After: 
![Screenshot from 2022-12-22 12-36-54](https://user-images.githubusercontent.com/5132349/209126509-6213cc66-1fd0-4edf-b515-de00406a1d42.png)
