### PR TITLE
fix: Safely call decodeURI()

### DIFF
--- a/src/Answer.tsx
+++ b/src/Answer.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import prettyTitle from "lodash.startcase";
 import styled from "@emotion/styled";
+import { safeDecodeURI } from "./helpers";
 
 type AnswerProps = React.PropsWithChildren<{
   title: string;
@@ -62,7 +63,7 @@ function Details(props: { data: any }): React.ReactElement<any, any> {
     return <span>{data}</span>;
   }
   if (typeof data === "string") {
-    return <span>{decodeURI(data)}</span>;
+    return <span>{safeDecodeURI(data)}</span>;
   }
   if (Array.isArray(data)) {
     return List(data);

--- a/src/example.json
+++ b/src/example.json
@@ -421,6 +421,27 @@
       "responses": [{ "value": "None of the above apply to me" }]
     },
     {
+      "metadata": {
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A.1 (b)"
+          }
+        ],
+        "portal_name": "Rear and side extensions to houses"
+      },
+      "question": "How much of the property is covered by extensions and outbuildings?",
+      "responses": [
+        {
+          "value": "50% or less of the available area around the original house",
+          "metadata": {
+            "flags": [
+              "Planning permission / Permitted development"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "metadata": { "portal_name": "declarations" },
       "question": "I confirm that:",
       "responses": [

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
-import { checkAnswerProps } from "./helpers";
+import { describe, expect, test } from "vitest";
+import { checkAnswerProps, safeDecodeURI } from "./helpers";
 
 test("checkAnswerProps", () => {
   expect(
@@ -10,4 +10,14 @@ test("checkAnswerProps", () => {
       },
     ])
   ).toBe(true);
+});
+
+describe("safeDecodeURI", () => {
+  test("It handles URI encoded strings", () => 
+    expect(safeDecodeURI("https://testURL.pizza/file%20with%20spaces.pdf")).toEqual("https://testURL.pizza/file with spaces.pdf")
+  );
+
+  test("It handles non-URI encoded strings", () => 
+    expect(safeDecodeURI("50% or less")).toEqual("50% or less")
+  );
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,3 +10,11 @@ export function checkAnswerProps(props: QuestionAnswer[]): boolean {
     })
   );
 }
+
+export function safeDecodeURI(data: string): string {
+  try {
+    return decodeURI(data)
+  } catch (error) {
+    return data
+  };
+};


### PR DESCRIPTION
Related to https://github.com/theopensystemslab/planx-new/pull/1383

**Problem**
Calling `decodeURI("50% or less of the available area around the original house")` throws an error, causing document generation (and submission) to fail in PlanX.

**Solution**
Pretty quick/dirty, but hopefully sufficient for now (opinions welcome!), but I've just wrapped `decodeURI()` in a try/catch so failing strings are logged out as plain text.